### PR TITLE
chore: change log status from error to notice for api result counts

### DIFF
--- a/ocha_countries/src/Controller/OchaCountriesController.php
+++ b/ocha_countries/src/Controller/OchaCountriesController.php
@@ -94,7 +94,7 @@ class OchaCountriesController extends OchaIntegrationsController {
 
     // Check if we have fewer countries then last time.
     if (count($keyed_data) < $this->state->get('ocha_countries_count')) {
-      $this->loggerFactory->get('ocha_countries')->error('We had @before countries before, now only @after', [
+      $this->loggerFactory->get('ocha_countries')->notice('We had @before countries before, now only @after', [
         '@before' => $this->state->get('ocha_countries_count'),
         '@after' => count($keyed_data),
       ]);

--- a/ocha_disasters/src/Controller/OchaDisastersController.php
+++ b/ocha_disasters/src/Controller/OchaDisastersController.php
@@ -122,7 +122,7 @@ class OchaDisastersController extends OchaIntegrationsController {
 
     // Check if we have fewer disasters then last time.
     if (count($keyed_data) < $this->state->get('ocha_disasters_count')) {
-      $this->loggerFactory->get('ocha_disasters')->error('We had @before disasters before, now only @after', [
+      $this->loggerFactory->get('ocha_disasters')->notice('We had @before disasters before, now only @after', [
         '@before' => $this->state->get('ocha_disasters_count'),
         '@after' => count($keyed_data),
       ]);

--- a/ocha_global_coordination_groups/src/Controller/OchaGlobalCoordinationGroupsController.php
+++ b/ocha_global_coordination_groups/src/Controller/OchaGlobalCoordinationGroupsController.php
@@ -94,7 +94,7 @@ class OchaGlobalCoordinationGroupsController extends OchaIntegrationsController 
 
     // Check if we have fewer countries then last time.
     if (count($keyed_data) < $this->state->get('ocha_global_coordination_groups_count')) {
-      $this->loggerFactory->get('ocha_global_coordination_groups')->error('We had @before countries before, now only @after', [
+      $this->loggerFactory->get('ocha_global_coordination_groups')->notice('We had @before countries before, now only @after', [
         '@before' => $this->state->get('ocha_global_coordination_groups_count'),
         '@after' => count($keyed_data),
       ]);

--- a/ocha_hid_contacts/src/Controller/OchaHidContactsController.php
+++ b/ocha_hid_contacts/src/Controller/OchaHidContactsController.php
@@ -122,7 +122,7 @@ class OchaHidContactsController extends OchaIntegrationsController {
 
     // Check if we have fewer local groups then last time.
     if (count($keyed_data) < $this->state->get('ocha_hid_contacts_count')) {
-      $this->loggerFactory->get('ocha_hid_contacts')->error('We had @before local groups before, now only @after', [
+      $this->loggerFactory->get('ocha_hid_contacts')->notice('We had @before local groups before, now only @after', [
         '@before' => $this->state->get('ocha_hid_contacts_count'),
         '@after' => count($keyed_data),
       ]);

--- a/ocha_local_groups/src/Controller/OchaLocalGroupsController.php
+++ b/ocha_local_groups/src/Controller/OchaLocalGroupsController.php
@@ -122,7 +122,7 @@ class OchaLocalGroupsController extends OchaIntegrationsController {
 
     // Check if we have fewer local groups then last time.
     if (count($keyed_data) < $this->state->get('ocha_local_groups_count')) {
-      $this->loggerFactory->get('ocha_local_groups')->error('We had @before local groups before, now only @after', [
+      $this->loggerFactory->get('ocha_local_groups')->notice('We had @before local groups before, now only @after', [
         '@before' => $this->state->get('ocha_local_groups_count'),
         '@after' => count($keyed_data),
       ]);

--- a/ocha_locations/src/Controller/OchaLocationsController.php
+++ b/ocha_locations/src/Controller/OchaLocationsController.php
@@ -190,7 +190,7 @@ class OchaLocationsController extends OchaIntegrationsController {
 
     // Check if we have fewer locations then last time.
     if (count($keyed_data) < $this->state->get('ocha_locations_count')) {
-      $this->loggerFactory->get($this->loggerId)->error('We had @before locations before, now only @after', [
+      $this->loggerFactory->get($this->loggerId)->notice('We had @before locations before, now only @after', [
         '@before' => $this->state->get('ocha_locations_count'),
         '@after' => count($keyed_data),
       ]);

--- a/ocha_organizations/src/Controller/OchaOrganizationsController.php
+++ b/ocha_organizations/src/Controller/OchaOrganizationsController.php
@@ -122,7 +122,7 @@ class OchaOrganizationsController extends OchaIntegrationsController {
 
     // Check if we have fewer organizations then last time.
     if (count($keyed_data) < $this->state->get('ocha_organizations_count')) {
-      $this->loggerFactory->get($this->loggerId)->error('We had @before organizations before, now only @after', [
+      $this->loggerFactory->get($this->loggerId)->notice('We had @before organizations before, now only @after', [
         '@before' => $this->state->get('ocha_organizations_count'),
         '@after' => count($keyed_data),
       ]);

--- a/ocha_population_type/src/Controller/OchaPopulationTypeController.php
+++ b/ocha_population_type/src/Controller/OchaPopulationTypeController.php
@@ -122,7 +122,7 @@ class OchaPopulationTypeController extends OchaIntegrationsController {
 
     // Check if we have fewer population type then last time.
     if (count($keyed_data) < $this->state->get('ocha_population_type_count')) {
-      $this->loggerFactory->get($this->loggerId)->error('We had @before population type before, now only @after', [
+      $this->loggerFactory->get($this->loggerId)->notice('We had @before population type before, now only @after', [
         '@before' => $this->state->get('ocha_population_type_count'),
         '@after' => count($keyed_data),
       ]);

--- a/ocha_themes/src/Controller/OchaThemesController.php
+++ b/ocha_themes/src/Controller/OchaThemesController.php
@@ -118,7 +118,7 @@ class OchaThemesController extends OchaIntegrationsController {
 
     // Check if we have fewer themes then last time.
     if (count($keyed_data) < $this->state->get('ocha_themes_count')) {
-      $this->loggerFactory->get($this->loggerId)->error('We had @before themes before, now only @after', [
+      $this->loggerFactory->get($this->loggerId)->notice('We had @before themes before, now only @after', [
         '@before' => $this->state->get('ocha_themes_count'),
         '@after' => count($keyed_data),
       ]);


### PR DESCRIPTION
Refs: AR-287

Low priority.

Still bugged by the repetitive error in the logs about the number of disasters, mainly, which changes every so often, I had a closer look and realised it's not an error, so we don't have to worry about it. 

![image](https://user-images.githubusercontent.com/67453/217069080-5107a69a-fa6e-45fe-be6c-28c0fb6677ba.png)


If the number is wildly different, perhaps we may want to flag it, but if the RW API reports a lower number of 'active' disasters, that's a good thing rather than an error.